### PR TITLE
SDPDEV-2 : update snvd-io launcher v2 as the default launcher

### DIFF
--- a/data/etc/privapp-permissions-platform.xml
+++ b/data/etc/privapp-permissions-platform.xml
@@ -49,9 +49,22 @@ applications that come with the platform
         <permission name="android.permission.READ_PRIVILEGED_PHONE_STATE" />
     </privapp-permissions>
 
-    <privapp-permissions package="com.android.launcher3">
+    <!--privapp-permissions package="com.android.launcher3">
         <permission name="android.permission.WRITE_SECURE_SETTINGS"/>
-    </privapp-permissions>
+    </privapp-permissions-->
+
+    <privapp-permissions package="com.codesteem.mylauncher">
+       <permission name="android.permission.WRITE_SECURE_SETTINGS"/>
+        <permission name="android.permission.ACCESS_NOTIFICATIONS" />
+       <permission name="android.permission.MANAGE_NOTIFICATIONS" />
+       <permission name="android.permission.BATTERY_STATS" />
+       <permission name="android.permission.READ_SMS" />
+       <permission name="android.permission.RECEIVE_SMS" />
+       <permission name="android.permission.SEND_SMS" />
+       <permission name="android.permission.WRITE_SETTINGS" />
+       <permission name="android.permission.READ_CALL_LOG" />
+       <permission name="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE"/>
+     </privapp-permissions>
 
     <privapp-permissions package="com.android.location.fused">
         <permission name="android.permission.INSTALL_LOCATION_PROVIDER"/>


### PR DESCRIPTION
Handle most of the permissions required by Launcher